### PR TITLE
[Feature Request] Add .clear() method to the timer class

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -3,7 +3,7 @@
  * This work is licensed under the terms of the MIT license.
  * For a copy, see the file LICENSE in the root directory.
  */
-
+import { clearIntervalAsync } from './clear'
 /**
  * Timer object returned by setIntervalAsync.<br>
  * Can be used together with {@link clearIntervalAsync} to stop execution.
@@ -13,6 +13,11 @@ class SetIntervalAsyncTimer {
     this.stopped = false
     this.timeouts = {}
     this.promises = {}
+  }
+
+  clear () {
+  //   console.log('clearring!!!!', this)
+    return clearIntervalAsync(this)
   }
 }
 

--- a/src/timer.js
+++ b/src/timer.js
@@ -3,7 +3,9 @@
  * This work is licensed under the terms of the MIT license.
  * For a copy, see the file LICENSE in the root directory.
  */
+
 import { clearIntervalAsync } from './clear'
+
 /**
  * Timer object returned by setIntervalAsync.<br>
  * Can be used together with {@link clearIntervalAsync} to stop execution.

--- a/src/timer.js
+++ b/src/timer.js
@@ -16,7 +16,6 @@ class SetIntervalAsyncTimer {
   }
 
   clear () {
-  //   console.log('clearring!!!!', this)
     return clearIntervalAsync(this)
   }
 }

--- a/test/clear.js
+++ b/test/clear.js
@@ -54,7 +54,7 @@ describe('clearIntervalAsync', () => {
       assert.deepEqual(timer.promises, {})
     })
 
-    it(`should clear timeouts from within the timer itself [${type}]`, async () => {
+    it(`should call the clear() method on the timer [${type}]`, async () => {
       let running = false
       const timer = setIntervalAsync(async () => {
         running = true

--- a/test/clear.js
+++ b/test/clear.js
@@ -36,12 +36,13 @@ describe('clearIntervalAsync', () => {
       let running = false
       const timer = setIntervalAsync(async () => {
         running = true
-        await sleep(100)
+        await sleep(300)
         running = false
       }, 10)
-      await sleep(150)
+      await sleep(100)
       assert.isTrue(running)
       await clearIntervalAsync(timer)
+      await sleep(500)
       assert.isFalse(running)
     })
 
@@ -58,12 +59,13 @@ describe('clearIntervalAsync', () => {
       let running = false
       const timer = setIntervalAsync(async () => {
         running = true
-        await sleep(100)
+        await sleep(300)
         running = false
       }, 10)
-      await sleep(150)
+      await sleep(100)
       assert.isTrue(running)
       await timer.clear()
+      await sleep(500)
       assert.isFalse(running)
     })
   }

--- a/test/clear.js
+++ b/test/clear.js
@@ -8,31 +8,30 @@ import { assert } from 'chai'
 import {
   clearIntervalAsync as clearIntervalAsyncD,
   setIntervalAsync as setIntervalAsyncD,
-  SetIntervalAsyncTimer as SetIntervalAsyncTimerD,
+  SetIntervalAsyncTimer as SetIntervalAsyncTimerD
 } from '../dynamic'
 import {
   clearIntervalAsync as clearIntervalAsyncF,
   setIntervalAsync as setIntervalAsyncF,
-  SetIntervalAsyncTimer as SetIntervalAsyncTimerF,
+  SetIntervalAsyncTimer as SetIntervalAsyncTimerF
 } from '../fixed'
 import {
   clearIntervalAsync as clearIntervalAsyncL,
   setIntervalAsync as setIntervalAsyncL,
-  SetIntervalAsyncTimer as SetIntervalAsyncTimerL,
+  SetIntervalAsyncTimer as SetIntervalAsyncTimerL
 } from '../legacy'
 import { sleep } from './util/sleep'
 
 describe('clearIntervalAsync', () => {
-
   for (const [type, [setIntervalAsync, clearIntervalAsync, SetIntervalAsyncTimer]] of [
     ['dynamic', [setIntervalAsyncD, clearIntervalAsyncD, SetIntervalAsyncTimerD]],
     ['fixed', [setIntervalAsyncF, clearIntervalAsyncF, SetIntervalAsyncTimerF]],
-    ['legacy', [setIntervalAsyncL, clearIntervalAsyncL, SetIntervalAsyncTimerL]],
+    ['legacy', [setIntervalAsyncL, clearIntervalAsyncL, SetIntervalAsyncTimerL]]
   ]) {
     it(`should clear an uninitialized timer without errors [${type}]`, async () => {
       await clearIntervalAsync(new SetIntervalAsyncTimer())
     })
-  
+
     it(`should wait until the interval is fully stopped [${type}]`, async () => {
       let running = false
       const timer = setIntervalAsync(async () => {
@@ -51,9 +50,21 @@ describe('clearIntervalAsync', () => {
       }, 10)
       await sleep(100)
       await clearIntervalAsync(timer)
-      assert.deepEqual(timer.timeouts, {});
-      assert.deepEqual(timer.promises, {});
+      assert.deepEqual(timer.timeouts, {})
+      assert.deepEqual(timer.promises, {})
+    })
+
+    it(`should clear timeouts from within the timer itself [${type}]`, async () => {
+      let running = false
+      const timer = setIntervalAsync(async () => {
+        running = true
+        await sleep(100)
+        running = false
+      }, 10)
+      await sleep(150)
+      assert.isTrue(running)
+      await timer.clear()
+      assert.isFalse(running)
     })
   }
-
 })


### PR DESCRIPTION
Howdy;
This is a great module, and really helps the not-so-edge case of repeating async calls.  Thanks for making it!

This PR adds a `.clear()` method directly to the `SetIntervalAsyncTimer` class that calls the `clearIntervalAsync()` method on the timer instance.

```js
// the setup
async function doTheWork() {
    await someLongJob();
}

const intervalTimer = setIntervalAsync(doTheWork, 1000);

// somewhere else in code...
await intervalTimer.clear();
``` 

This eliminates having to import  `setIntervalAsync` separately in other parts of the code if you already have a timer, and makes the timer returned a more self-contained manager for the ongoing interval.  People could continue to use `setIntervalAsync` the same way (the `timer` still validates), but would give them another  way to clear the interval.

Thanks for taking a look.